### PR TITLE
Change default location

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import Sqlite from 'better-sqlite3';
-import { join } from 'path';
 
 // Methods
 import { Arbitrate, MethodOptions } from './methods/methods';

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ const Hasty: HastyConstructor = function (this: Hasty | void, file?: string) {
     const HastyThis = this;
 
     // Specify file location
-    HastyThis!.file_location = file || join(__dirname, './data.sqlite');
+    HastyThis!.file_location = file || 'data.sqlite';
 
     // Create database
     let database = Sqlite(this.file_location);


### PR DESCRIPTION
Changing the default location from `/node_modules/hasty.db/data.sqlite` to `/data.sqlite`.